### PR TITLE
Add developer profile CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # CLI-profile
+
+A simple command-line tool to show a developer profile.
+
+## Installation
+
+Clone the repository and install any dependencies listed in `requirements.txt` (none are strictly required for basic usage).
+
+```bash
+pip install -r requirements.txt  # optional, currently empty
+```
+
+## Usage
+
+Run the CLI with Python:
+
+```bash
+python cli.py --help
+```
+
+Available commands:
+
+- `summary`: display a brief introduction.
+- `skills`: list skills.
+- `projects`: list projects.
+
+You can also get the version with `--version`.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Developer profile CLI."""
+
+import argparse
+from profile import summary, get_skills, get_projects
+
+__version__ = "0.1.0"
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(description="Developer profile CLI")
+    parser.add_argument("--version", action="version", version=__version__)
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    subparsers.add_parser("summary", help="Show developer summary")
+    subparsers.add_parser("skills", help="List skills")
+    subparsers.add_parser("projects", help="List projects")
+
+    parsed = parser.parse_args(args)
+
+    if parsed.command == "summary":
+        print(summary())
+    elif parsed.command == "skills":
+        print("Skills:\n- " + "\n- ".join(get_skills()))
+    elif parsed.command == "projects":
+        for name, desc in get_projects().items():
+            print(f"{name}: {desc}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/profile/__init__.py
+++ b/profile/__init__.py
@@ -1,0 +1,22 @@
+"""Helper functions to access profile data."""
+
+from . import data
+
+
+def summary():
+    """Return a formatted summary string of the developer profile."""
+    lines = [
+        f"Name: {data.NAME}",
+        f"Role: {data.ROLE}",
+        f"Experience: {data.YEARS_EXPERIENCE} years",
+        "Skills: " + ", ".join(data.SKILLS),
+    ]
+    return "\n".join(lines)
+
+
+def get_skills():
+    return data.SKILLS
+
+
+def get_projects():
+    return data.PROJECTS

--- a/profile/data.py
+++ b/profile/data.py
@@ -1,0 +1,17 @@
+# Basic developer information for CLI output
+
+NAME = "Your Name"
+ROLE = "Software Developer"
+YEARS_EXPERIENCE = 3
+
+SKILLS = [
+    "Python",
+    "Flask",
+    "JavaScript",
+    "Docker",
+]
+
+PROJECTS = {
+    "CLI Profile": "A command-line tool that showcases my developer profile.",
+    "Web API": "A RESTful API built using Flask and PostgreSQL.",
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No external dependencies required


### PR DESCRIPTION
## Summary
- implement a simple CLI (`cli.py`) for displaying a developer profile
- store profile data and helper functions in the `profile` package
- document usage in README
- add empty `requirements.txt`

## Testing
- `python3 cli.py --help`
- `python3 cli.py summary`
- `python3 -m py_compile cli.py profile/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6846ac20d20c8327a3ef3ee1d1ceac54